### PR TITLE
Remove attribute call

### DIFF
--- a/pypianoroll/multitrack.py
+++ b/pypianoroll/multitrack.py
@@ -963,7 +963,7 @@ class Multitrack(object):
             The number of semitones to transpose the pianorolls.
 
         """
-        for track in self.tracks():
+        for track in self.tracks:
             if not track.is_drum:
                 track.transpose(semitone)
 


### PR DESCRIPTION
[This line](https://github.com/salu133445/pypianoroll/blob/cfd8fc425408aa890ab0a549b99f5014f0344902/pypianoroll/multitrack.py#L966) throws a `TypeError`:

    TypeError: 'list' object is not callable

P.s.: Thanks for this beautiful package!