### PR TITLE
Fix _to_chroma used in n_pitche_class_used calculation

### DIFF
--- a/pypianoroll/metrics.py
+++ b/pypianoroll/metrics.py
@@ -23,7 +23,7 @@ def _to_chroma(pianoroll):
     _validate_pianoroll(pianoroll)
     reshaped = pianoroll[:, :120].reshape(-1, 12, 10)
     reshaped[..., :8] += pianoroll[:, 120:].reshape(-1, 1, 8)
-    return np.sum(reshaped, 1)
+    return np.sum(reshaped, -1)
 
 def empty_beat_rate(pianoroll, beat_resolution):
     """Return the ratio of empty beats to the total number of beats in a


### PR DESCRIPTION
Sum over last dimension of reshaped pianoroll instead of penultimate.
Penultimate dimension is for chroma, whereas last dimension is the
number of octaves in a given chroma.

I understand n_pitche_class_used is used to compute the number of pitch classes (A, A#, B, C, etc) activated in the pianoroll. So the function computing the chroma vector should have shape (length, 12), where length is the length of the pianoroll.
I noticed a mistake in the summation in `pypianoroll.metrics._to_chroma` function which gives wrong result in `pypianoroll.metrics.n_pitche_class_used`, and returns a chroma vector of shape (length, 10) instead.

Thanks for any feedback.