### PR TITLE
Added Tempo Changes to pretty midi

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Working files
+*.mid
+*.midi
+# add any permanent files with git add -f
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/doc/source/read_write.rst
+++ b/doc/source/read_write.rst
@@ -20,4 +20,4 @@ Functions
     :noindex:
 
 .. note::
-    Writing the tempo array and downbeat array to tempo change and time signature change events are not supported yet.
+    Writing the downbeat array to time signature change events is not supported yet.

--- a/docs/_sources/read_write.rst.txt
+++ b/docs/_sources/read_write.rst.txt
@@ -20,4 +20,4 @@ Functions
     :noindex:
 
 .. note::
-    Writing the tempo array and downbeat array to tempo change and time signature change events are not supported yet.
+    Writing the downbeat array to time signature change events is not supported yet.

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -10,7 +10,7 @@
   <!--[if lt IE 9]>
     <script src="_static/js/html5shiv.min.js"></script>
   <![endif]-->
-  
+
         <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
         <script src="_static/jquery.js"></script>
         <script src="_static/underscore.js"></script>
@@ -19,10 +19,10 @@
     <script src="_static/js/theme.js"></script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
-    <link rel="prev" title="Metrics" href="metrics.html" /> 
+    <link rel="prev" title="Metrics" href="metrics.html" />
 </head>
 
-<body class="wy-body-for-nav"> 
+<body class="wy-body-for-nav">
   <div class="wy-grid-for-nav">
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
@@ -71,7 +71,7 @@
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
-             
+
   <section id="module-pypianoroll">
 <span id="technical-documentation"></span><h1>Technical Documentation<a class="headerlink" href="#module-pypianoroll" title="Permalink to this headline"></a></h1>
 <p>A Python library for handling multitrack pianorolls.</p>
@@ -1797,8 +1797,7 @@ arrays are then collected and saved to a npz file.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, use its
-first element.</p></li>
+<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes that occur.</p></li>
 <li><p><strong>default_velocity</strong> (int, default: <cite>pypianoroll.DEFAULT_VELOCITY</cite> (64)) – Default velocity to assign to binarized tracks.</p></li>
 </ul>
 </dd>
@@ -1928,7 +1927,7 @@ pitches, while a negative value lowers the pitches.</p></li>
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a
     <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a>
     provided by <a href="https://readthedocs.org">Read the Docs</a>.
-   
+
 
 </footer>
         </div>
@@ -1939,7 +1938,7 @@ pitches, while a negative value lowers the pitches.</p></li>
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script> 
+  </script>
 
 </body>
 </html>

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -1797,7 +1797,7 @@ arrays are then collected and saved to a npz file.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes that occur.</p></li>
+<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes and time signature changes that occur.</p></li>
 <li><p><strong>default_velocity</strong> (int, default: <cite>pypianoroll.DEFAULT_VELOCITY</cite> (64)) – Default velocity to assign to binarized tracks.</p></li>
 </ul>
 </dd>
@@ -1810,8 +1810,7 @@ arrays are then collected and saved to a npz file.</p>
 </dl>
 <p class="rubric">Notes</p>
 <ul class="simple">
-<li><p>Tempo changes are not supported.</p></li>
-<li><p>Time signature changes are not supported.</p></li>
+<li><p>Time signature changes default to */4.</p></li>
 <li><p>The velocities of the converted piano rolls will be clipped to
 [0, 127].</p></li>
 <li><p>Adjacent nonzero values of the same pitch will be considered

--- a/docs/read_write.html
+++ b/docs/read_write.html
@@ -178,7 +178,7 @@ than one beat are dropped.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes that occur.</p></li>
+<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes and time signature changes that occur.</p></li>
 <li><p><strong>default_velocity</strong> (int, default: <cite>pypianoroll.DEFAULT_VELOCITY</cite> (64)) – Default velocity to assign to binarized tracks.</p></li>
 </ul>
 </dd>
@@ -191,8 +191,7 @@ than one beat are dropped.</p>
 </dl>
 <p class="rubric">Notes</p>
 <ul class="simple">
-<li><p>Tempo changes are not supported.</p></li>
-<li><p>Time signature changes are not supported.</p></li>
+<li><p>Time signature changes default to */4.</p></li>
 <li><p>The velocities of the converted piano rolls will be clipped to
 [0, 127].</p></li>
 <li><p>Adjacent nonzero values of the same pitch will be considered

--- a/docs/read_write.html
+++ b/docs/read_write.html
@@ -10,7 +10,7 @@
   <!--[if lt IE 9]>
     <script src="_static/js/html5shiv.min.js"></script>
   <![endif]-->
-  
+
         <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
         <script src="_static/jquery.js"></script>
         <script src="_static/underscore.js"></script>
@@ -19,10 +19,10 @@
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="Visualization" href="visualization.html" />
-    <link rel="prev" title="Save &amp; Load" href="save_load.html" /> 
+    <link rel="prev" title="Save &amp; Load" href="save_load.html" />
 </head>
 
-<body class="wy-body-for-nav"> 
+<body class="wy-body-for-nav">
   <div class="wy-grid-for-nav">
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
@@ -71,7 +71,7 @@
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
-             
+
   <section id="read-write">
 <h1>Read &amp; Write<a class="headerlink" href="#read-write" title="Permalink to this headline"></a></h1>
 <p>Pypianoroll currently supports reading from and writing to MIDI files.</p>
@@ -178,8 +178,7 @@ than one beat are dropped.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, use its
-first element.</p></li>
+<li><p><strong>default_tempo</strong> (int, default: <cite>pypianoroll.DEFAULT_TEMPO</cite> (120)) – Default tempo to use. If attribute <cite>tempo</cite> is available, encorporate it into the midi file with any tempo changes that occur.</p></li>
 <li><p><strong>default_velocity</strong> (int, default: <cite>pypianoroll.DEFAULT_VELOCITY</cite> (64)) – Default velocity to assign to binarized tracks.</p></li>
 </ul>
 </dd>
@@ -203,7 +202,7 @@ a single note with their mean as its velocity.</p></li>
 
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Writing the tempo array and downbeat array to tempo change and time signature change events are not supported yet.</p>
+<p>Writing the downbeat array to time signature change events is not supported yet.</p>
 </div>
 </section>
 </section>
@@ -225,7 +224,7 @@ a single note with their mean as its velocity.</p></li>
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a
     <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a>
     provided by <a href="https://readthedocs.org">Read the Docs</a>.
-   
+
 
 </footer>
         </div>
@@ -236,7 +235,7 @@ a single note with their mean as its velocity.</p></li>
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script> 
+  </script>
 
 </body>
 </html>

--- a/pypianoroll/inputs.py
+++ b/pypianoroll/inputs.py
@@ -234,7 +234,7 @@ def from_pretty_midi(
     one_more_beat = 2 * beat_times[-1] - beat_times[-2]
     beat_times_one_more = np.append(beat_times, one_more_beat)
     bpm = 60.0 / np.diff(beat_times_one_more)
-    tempo = np.tile(bpm, (1, 24)).reshape(-1, 1)
+    tempo = np.repeat(bpm, resolution).reshape(-1, 1)
 
     # Parse the tracks
     tracks = []

--- a/pypianoroll/inputs.py
+++ b/pypianoroll/inputs.py
@@ -205,7 +205,7 @@ def from_pretty_midi(
 
     # Parse downbeat array
     if not midi.time_signature_changes:
-        # This probably won't happen as pretty_midi always add a 4/4 time
+        # This probably won't happen as pretty_midi always adds a 4/4 time
         # signature at time 0
         beat = None
         downbeat = None

--- a/pypianoroll/metrics.py
+++ b/pypianoroll/metrics.py
@@ -188,7 +188,7 @@ def qualified_note_rate(pianoroll: ndarray, threshold: float = 2) -> float:
        2018.
 
     """
-    if np.issubdtype(pianoroll.dtype, np.bool_):
+    if np.issubdtype(pianoroll.dtype, bool):
         pianoroll = pianoroll.astype(np.uint8)
     padded = np.pad(pianoroll, ((1, 1), (0, 0)), "constant")
     diff = np.diff(padded, axis=0).reshape(-1)

--- a/pypianoroll/multitrack.py
+++ b/pypianoroll/multitrack.py
@@ -187,7 +187,7 @@ class Multitrack:
         elif attr == "beat":
             if not isinstance(self.beat, np.ndarray):
                 raise TypeError("`beat` must be a NumPy array.")
-            if not np.issubdtype(self.beat.dtype, np.bool_):
+            if not np.issubdtype(self.beat.dtype, bool):
                 raise TypeError(
                     "`beat` must be of data type bool, but got data type"
                     f"{self.beat.dtype}."
@@ -195,7 +195,7 @@ class Multitrack:
         elif attr == "downbeat":
             if not isinstance(self.downbeat, np.ndarray):
                 raise TypeError("`downbeat` must be a NumPy array.")
-            if not np.issubdtype(self.downbeat.dtype, np.bool_):
+            if not np.issubdtype(self.downbeat.dtype, bool):
                 raise TypeError(
                     "`downbeat` must be of data type bool, but got data type"
                     f"{self.downbeat.dtype}."

--- a/pypianoroll/multitrack.py
+++ b/pypianoroll/multitrack.py
@@ -96,8 +96,17 @@ class Multitrack:
         else:
             self.resolution = DEFAULT_RESOLUTION
 
+        if tracks is None:
+            self.tracks = []
+        elif isinstance(tracks, list):
+            self.tracks = tracks
+        else:
+            self.tracks = list(tracks)
+
         if tempo is None:
             self.tempo = None
+        elif isinstance(tempo, int) or isinstance(tempo, float):
+            self.tempo = np.tile(tempo, (self.get_max_length(), 1)).astype(float)
         elif np.issubdtype(tempo.dtype, np.floating):
             self.tempo = tempo
         else:
@@ -116,13 +125,6 @@ class Multitrack:
             self.downbeat = downbeat
         else:
             self.downbeat = np.asarray(downbeat).astype(bool)
-
-        if tracks is None:
-            self.tracks = []
-        elif isinstance(tracks, list):
-            self.tracks = tracks
-        else:
-            self.tracks = list(tracks)
 
     def __len__(self) -> int:
         return len(self.tracks)
@@ -248,7 +250,7 @@ class Multitrack:
             if self.resolution < 1:
                 raise ValueError("`resolution` must be a positive integer.")
         elif attr == "tempo":
-            if self.tempo.ndim != 1:
+            if self.tempo.ndim != 2:
                 raise ValueError("`tempo` must be a 2D NumPy array of shape (?,1)")
             if np.any(self.tempo <= 0.0):
                 raise ValueError("`tempo` must contain only positive numbers.")

--- a/pypianoroll/multitrack.py
+++ b/pypianoroll/multitrack.py
@@ -249,15 +249,15 @@ class Multitrack:
                 raise ValueError("`resolution` must be a positive integer.")
         elif attr == "tempo":
             if self.tempo.ndim != 1:
-                raise ValueError("`tempo` must be a 1D NumPy array.")
+                raise ValueError("`tempo` must be a 2D NumPy array of shape (?,1)")
             if np.any(self.tempo <= 0.0):
                 raise ValueError("`tempo` must contain only positive numbers.")
         elif attr == "beat":
             if self.beat.ndim != 1:
                 raise ValueError("`beat` must be a 1D NumPy array.")
         elif attr == "downbeat":
-            if self.downbeat.ndim != 1:
-                raise ValueError("`downbeat` must be a 1D NumPy array.")
+            if self.downbeat.ndim != 2 or self.downbeat.shape[1] != 1:
+                raise ValueError("`downbeat` must be a 2D NumPy array of shape (?,1).")
         elif attr == "tracks":
             for track in self.tracks:
                 track.validate()

--- a/pypianoroll/multitrack.py
+++ b/pypianoroll/multitrack.py
@@ -11,7 +11,7 @@ Variable
 - DEFAULT_RESOLUTION
 
 """
-from typing import List, Sequence, TypeVar
+from typing import List, Sequence, TypeVar, Union
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -66,7 +66,8 @@ class Multitrack:
         Time steps per quarter note.
     tempo : ndarray, dtype=float, shape=(?, 1), optional
         Tempo (in qpm) at each time step. Length is the total number
-        of time steps. Cast to float if not of float type.
+        of time steps. Cast to float if not of float type. Alternatively,
+        enter a single float or integer and the array will be generated.
     beat : ndarray, dtype=bool, shape=(?, 1), optional
         A boolean array that indicates whether the time step contains a
         beat. Length is the total number of time steps. Cast to bool if
@@ -84,7 +85,7 @@ class Multitrack:
         self,
         name: str = None,
         resolution: int = None,
-        tempo: ndarray = None,
+        tempo: Union[ndarray, int, float] = None,
         beat: ndarray = None,
         downbeat: ndarray = None,
         tracks: Sequence[Track] = None,

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -208,6 +208,16 @@ def to_pretty_midi(
         instrument.notes.sort(key=attrgetter("start"))
         midi.instruments.append(instrument)
 
+    # Find downbeat positions in time
+    downbeats = np.concatenate((multitrack.downbeat[:,0], (True,)))
+    indices = np.where(downbeats)[0]
+
+    time_signature_changes = []
+    for i in range(len(indices) - 1):
+        beats = int((indices[i+1] - indices[i]) / multitrack.resolution)
+        time = prefix[indices[i]] if i != 0 else 0
+        midi.time_signature_changes.append(pretty_midi.TimeSignature(beats, 4, time))
+
     return midi
 
 

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -192,7 +192,7 @@ def to_pretty_midi(
         pitches = positives[0]
         note_ons = positives[1]
         note_on_times = prefix[note_ons]
-        note_offs = np.nonzero((diff < 0).T)[1]
+        note_offs = np.nonzero((diff < 0).T)[1] + 1
         note_off_times = prefix[note_offs]
 
         for idx, pitch in enumerate(pitches):

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Dict, Union
 
 import numpy as np
 import pretty_midi
-import scipy.stats
 from pretty_midi import Instrument, PrettyMIDI
 
 from .track import BinaryTrack, StandardTrack
@@ -135,12 +134,11 @@ def to_pretty_midi(
 
     """
     if default_tempo is not None:
-        tempo = default_tempo
+        tempo = np.full(multitrack.get_max_length(), default_tempo)
     elif multitrack.tempo is not None:
-        # tempo = float(scipy.stats.hmean(multitrack.tempo))
         tempo = multitrack.tempo[:,0]
     else:
-        tempo = DEFAULT_TEMPO
+        tempo = np.full(multitrack.get_max_length(), DEFAULT_TEMPO)
 
     # Create a PrettyMIDI instance
     midi = PrettyMIDI(initial_tempo=tempo[0])

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -208,14 +208,14 @@ def to_pretty_midi(
         instrument.notes.sort(key=attrgetter("start"))
         midi.instruments.append(instrument)
 
-    # Find downbeat positions in time
+    # Find downbeat positions
     downbeats = np.concatenate((multitrack.downbeat[:,0], (True,)))
     indices = np.where(downbeats)[0]
 
-    time_signature_changes = []
     for i in range(len(indices) - 1):
+        # Calculate number of beats
         beats = int((indices[i+1] - indices[i]) / multitrack.resolution)
-        time = prefix[indices[i]] if i != 0 else 0
+        time = prefix[indices[i]] if i != 0 else 0 # include timesignature at time 0
         midi.time_signature_changes.append(pretty_midi.TimeSignature(beats, 4, time))
 
     return midi

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -208,20 +208,21 @@ def to_pretty_midi(
         instrument.notes.sort(key=attrgetter("start"))
         midi.instruments.append(instrument)
 
-    # Find downbeat positions
-    downbeats = np.concatenate((multitrack.downbeat[:,0], (True,)))
-    indices = np.where(downbeats)[0]
+    if multitrack.downbeat is not None:
+        # Find downbeat positions
+        downbeats = np.concatenate((multitrack.downbeat[:,0], (True,)))
+        indices = np.where(downbeats)[0]
 
-    for i in range(len(indices) - 1):
-        # Calculate number of beats
-        beats = Fraction((indices[i+1] - indices[i]) / multitrack.resolution / 4).limit_denominator(16)
-        time = prefix[indices[i]] if i != 0 else 0 # include timesignature at time 0
-        # Find the first denominator that fits into the beat without 1/*
-        beat_denominators = [4, 8, 16]
-        for denominator in beat_denominators:
-            if denominator % beats.denominator == 0 and (denominator == beat_denominators[-1] or beats.numerator * denominator // beats.denominator != 1):
-                midi.time_signature_changes.append(pretty_midi.TimeSignature(beats.numerator * denominator // beats.denominator, denominator, time))
-                break
+        for i in range(len(indices) - 1):
+            # Calculate number of beats
+            beats = Fraction((indices[i+1] - indices[i]) / multitrack.resolution / 4).limit_denominator(16)
+            time = prefix[indices[i]] if i != 0 else 0 # include timesignature at time 0
+            # Find the first denominator that fits into the beat without 1/*
+            beat_denominators = [4, 8, 16]
+            for denominator in beat_denominators:
+                if denominator % beats.denominator == 0 and (denominator == beat_denominators[-1] or beats.numerator * denominator // beats.denominator != 1):
+                    midi.time_signature_changes.append(pretty_midi.TimeSignature(beats.numerator * denominator // beats.denominator, denominator, time))
+                    break
 
     return midi
 

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -113,7 +113,8 @@ def to_pretty_midi(
     Parameters
     ----------
     default_tempo : int, default: `pypianoroll.DEFAULT_TEMPO` (120)
-        Default tempo to use. If attribute `tempo` is available, encorporate it into the midi file with any tempo changes that occur
+        Default tempo to use. If attribute `tempo` is available, encorporate
+        it into the midi file with any tempo changes that occur
     default_velocity : int, default: `pypianoroll.DEFAULT_VELOCITY` (64)
         Default velocity to assign to binarized tracks.
 

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -113,8 +113,7 @@ def to_pretty_midi(
     Parameters
     ----------
     default_tempo : int, default: `pypianoroll.DEFAULT_TEMPO` (120)
-        Default tempo to use. If attribute `tempo` is available, use its
-        first element.
+        Default tempo to use. If attribute `tempo` is available, encorporate it into the midi file with any tempo changes that occur
     default_velocity : int, default: `pypianoroll.DEFAULT_VELOCITY` (64)
         Default velocity to assign to binarized tracks.
 

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -192,7 +192,7 @@ def to_pretty_midi(
         pitches = positives[0]
         note_ons = positives[1]
         note_on_times = prefix[note_ons]
-        note_offs = np.nonzero((diff < 0).T)[1] + 1
+        note_offs = np.nonzero((diff < 0).T)[1]
         note_off_times = prefix[note_offs]
 
         for idx, pitch in enumerate(pitches):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         include=["pypianoroll", "pypianoroll.*"], exclude=["tests"]
     ),
     install_requires=[
-        "numpy>=1.12.0",
+        "numpy>=1.12.0,<1.24",
         "scipy>=1.0.0",
         "pretty_midi>=0.2.8",
         "matplotlib>=1.5",

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -11,7 +11,7 @@ def test_repr(multitrack):
     assert repr(multitrack) == (
         "Multitrack(name='test', resolution=24, "
         "beat=array(shape=(96,), dtype=bool), "
-        "downbeat=array(shape=(96,), dtype=bool), tracks=["
+        "downbeat=array(shape=(96, 1), dtype=bool), tracks=["
         "StandardTrack(name='track_1', program=0, is_drum=False, "
         "pianoroll=array(shape=(96, 128), dtype=uint8)), "
         "BinaryTrack(name='track_2', program=0, is_drum=True, "
@@ -93,8 +93,8 @@ def multitrack_to_blend():
     track_2 = StandardTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2
     )
-    downbeat = np.zeros((96,), bool)
-    downbeat[0] = True
+    downbeat = np.zeros((96, 1), bool)
+    downbeat[0,0] = True
     return Multitrack(
         name="test",
         resolution=24,
@@ -155,8 +155,8 @@ def test_pad_to_same(multitrack):
     track_2 = BinaryTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2
     )
-    downbeat = np.zeros((96,), bool)
-    downbeat[0] = True
+    downbeat = np.zeros((96, 1), bool)
+    downbeat[0,0] = True
     multitrack = Multitrack(
         name="test",
         resolution=24,
@@ -178,8 +178,8 @@ def test_remove_empty():
     track_2 = StandardTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2
     )
-    downbeat = np.zeros((96,), bool)
-    downbeat[0] = True
+    downbeat = np.zeros((96, 1), bool)
+    downbeat[0,0] = True
     multitrack = Multitrack(
         name="test",
         resolution=24,

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -8,8 +8,10 @@ from .utils import multitrack
 
 
 def test_repr(multitrack):
+    # print(repr(multitrack))
     assert repr(multitrack) == (
         "Multitrack(name='test', resolution=24, "
+        "tempo=array(shape=(96, 1), dtype=float64), "
         "beat=array(shape=(96,), dtype=bool), "
         "downbeat=array(shape=(96, 1), dtype=bool), tracks=["
         "StandardTrack(name='track_1', program=0, is_drum=False, "
@@ -44,6 +46,10 @@ def test_get_beat_steps(multitrack):
 def test_get_downbeat_steps(multitrack):
     assert np.all(multitrack.get_downbeat_steps() == [0])
 
+
+def test_tempo(multitrack):
+    assert multitrack.tempo.shape == (96, 1)
+    assert np.allclose(multitrack.tempo, 120)
 
 def test_set_nonzeros(multitrack):
     multitrack.set_nonzeros(50)

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -125,7 +125,7 @@ def test_blend_max(multitrack_to_blend):
 
 
 def test_append(multitrack):
-    pianoroll = np.zeros((96, 128), np.bool_)
+    pianoroll = np.zeros((96, 128), bool)
     pianoroll[:95:16, 41] = True
     track_to_append = BinaryTrack(name="track_3", pianoroll=pianoroll)
     multitrack.append(track_to_append)
@@ -150,7 +150,7 @@ def test_pad_to_same(multitrack):
     track_1 = StandardTrack(
         name="track_1", program=0, is_drum=False, pianoroll=pianoroll_1
     )
-    pianoroll_2 = np.zeros((96, 128), np.bool)
+    pianoroll_2 = np.zeros((96, 128), bool)
     pianoroll_2[0:95:16, 36] = True
     track_2 = BinaryTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2
@@ -174,7 +174,7 @@ def test_remove_empty():
     track_1 = StandardTrack(
         name="track_1", program=0, is_drum=False, pianoroll=pianoroll_1
     )
-    pianoroll_2 = np.zeros((96, 128), np.bool)
+    pianoroll_2 = np.zeros((96, 128), bool)
     track_2 = StandardTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,8 +19,8 @@ def multitrack():
     )
     beat = np.zeros((96,), bool)
     beat[:96:24] = True
-    downbeat = np.zeros((96,), bool)
-    downbeat[0] = True
+    downbeat = np.zeros((96,1), bool)
+    downbeat[0,0] = True
     return Multitrack(
         name="test",
         resolution=24,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,4 +27,5 @@ def multitrack():
         beat=beat,
         downbeat=downbeat,
         tracks=[track_1, track_2],
+        tempo=120
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ def multitrack():
     track_1 = StandardTrack(
         name="track_1", program=0, is_drum=False, pianoroll=pianoroll_1
     )
-    pianoroll_2 = np.zeros((96, 128), np.bool)
+    pianoroll_2 = np.zeros((96, 128), bool)
     pianoroll_2[:95:16, 36] = True
     track_2 = BinaryTrack(
         name="track_2", program=0, is_drum=True, pianoroll=pianoroll_2


### PR DESCRIPTION
Hi,
-  I've made a few changes to the repository to preserve tempo changes when saving. To do this, I've modified the `to_pretty_midi` function using some of the code directly from *pretty-midi* to add tempo changes using ticks. 
- I also modified the `load` function as this wasn't saving the tempi to the array correctly.
- I updated references to `np.bool` to `bool` to be compatible with new versions of `numpy`
- I tried to format and update the documentation but I'm not sure that worked.