### PR TITLE
Fixed ytick == "step" typo in plot_pianoroll

### DIFF
--- a/pypianoroll/visualization.py
+++ b/pypianoroll/visualization.py
@@ -202,7 +202,7 @@ def plot_pianoroll(
         ax.set_yticks(np.arange(0, 128, 12))
         if yticklabel == "name":
             ax.set_yticklabels([f"C{i - 2}" for i in range(11)])
-    elif ytick == "step":
+    elif ytick == "pitch":
         ax.set_yticks(np.arange(0, 128))
         if yticklabel == "name":
             if is_drum:


### PR DESCRIPTION
It took me a bit to realize why I was getting and error when I set the parameter `ytick='pitch'` on plot_pianoroll, documentation/docstring were alright. I checked for more similar typos just in case but didn't find any.