### PR TITLE
Fixing writing to io.BytesIO

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "[markdown]": {
         "editor.codeActionsOnSave": {
-            "source.fixAll.markdownlint": true
+            "source.fixAll.markdownlint": "explicit"
         },
         "editor.minimap.enabled": false,
         "editor.wordWrap": "wordWrapColumn",
@@ -9,7 +9,7 @@
     },
     "[python]": {
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
         "editor.formatOnSave": true
     },

--- a/pypianoroll/outputs.py
+++ b/pypianoroll/outputs.py
@@ -205,4 +205,5 @@ def write(path: str, multitrack: "Multitrack"):
     :func:`pypianoroll.save` : Save a Multitrack object to a NPZ file.
 
     """
-    return to_pretty_midi(multitrack).write(str(path))
+    return to_pretty_midi(multitrack).write(path) # __max__ commented line below
+    # return to_pretty_midi(multitrack).write(str(path))


### PR DESCRIPTION
Hi!

This includes a very minor change (I've also kept the previous version in a comment).

Before the fix, I was not able to do write Multitrack object to an io.BytesIO "file". With this change, I was able to run the following:

```python
# initialize bytes handle
b_handle = io.BytesIO()
# write midi data to bytes handle
pianoroll_structure.write(b_handle)
```
I will be happy to clean up the comment in the code myself, if you find that this change might be useful. Thanks!